### PR TITLE
chore: post exec message refers to proper subdir

### DIFF
--- a/setup.sh
+++ b/setup.sh
@@ -199,7 +199,7 @@ else
     echo -e "${GREEN}Setting up compose dev...${NOCOLOR}"
     git clone git@github.com:bigcartel/compose-dev.git
 
-    echo -e "${YELLOW}The final step is to cd to $BC_HOME/compose_dev and run ./setup.sh${NOCOLOR}"
-    echo -e "${YELLOW}compose_dev is the base checkout of our docker-compose based dev environment${NOCOLOR}"
+    echo -e "${YELLOW}The final step is to cd to $BC_HOME/compose-dev and run ./setup.sh${NOCOLOR}"
+    echo -e "${YELLOW}compose-dev is the base checkout of our docker-compose based dev environment${NOCOLOR}"
     echo -e "${YELLOW}The setup script will build container images and bootstap the actual dev environment${NOCOLOR}"
 fi


### PR DESCRIPTION
After checking for compose-dev, the final message now properly instructs the user to run the setup script in `compose-dev` instead of `compose_dev`.