### PR TITLE
[bug] Prevents noisy failures for missing dev vault credentials

### DIFF
--- a/setup.sh
+++ b/setup.sh
@@ -111,7 +111,6 @@ else
 fi
 
 # avoids an edgecase where employees do not have 1password accounts set up
-BC_RAW_1PASS_ID="CMUGFRT7Y5BRJMYKQIXJDO2654"
 echo -ne "${YELLOW}Testing Access to developer vaults...${NOCOLOR} "
 if op --account $BIGCARTEL_RAW_1PASS_ID item get "Rails Secrets [admin]" > /dev/null 2>&1; then
     echo -e "${GREEN}Success${NOCOLOR}"

--- a/setup.sh
+++ b/setup.sh
@@ -100,9 +100,7 @@ else
 fi
 
 echo -ne "${YELLOW}Testing 1Password CLI...${NOCOLOR} "
-last_exit=0
-op account get --account bigcartel > /dev/null || last_exit=$?
-if [ $last_exit -eq 0 ]; then
+if op account get --account bigcartel > /dev/null 2>&1; then
     echo -e "${GREEN}Success${NOCOLOR}"
 else
     echo -e "${RED}Failed${NOCOLOR}"
@@ -111,9 +109,7 @@ else
 fi
 
 echo -ne "${YELLOW}Testing Access to developer vaults...${NOCOLOR} "
-last_exit=0
-op --account bigcartel item get "Rails Secrets [admin]" > /dev/null || last_exit=$?
-if [ $last_exit -eq 0 ]; then
+if op --account bigcartel item get "Rails Secrets [admin]" > /dev/null 2>&1; then
     echo -e "${GREEN}Success${NOCOLOR}"
 else
     echo -e "${RED}Failed${NOCOLOR}"

--- a/setup.sh
+++ b/setup.sh
@@ -8,7 +8,6 @@ NOCOLOR="\033[0m"
 # avoids an edgecase where employees do not have 1password accounts set up
 BC_RAW_1PASS_ID="CMUGFRT7Y5BRJMYKQIXJDO2654"
 
-
 function abort {
     echo -e "\n${RED}Exiting early, please re-run after correcting errors!${NOCOLOR}"
     exit 1

--- a/setup.sh
+++ b/setup.sh
@@ -112,7 +112,7 @@ fi
 
 # avoids an edgecase where employees do not have 1password accounts set up
 echo -ne "${YELLOW}Testing Access to developer vaults...${NOCOLOR} "
-if op --account $BIGCARTEL_RAW_1PASS_ID item get "Rails Secrets [admin]" > /dev/null 2>&1; then
+if op --account $BC_RAW_1PASS_ID item get "Rails Secrets [admin]" > /dev/null 2>&1; then
     echo -e "${GREEN}Success${NOCOLOR}"
 else
     echo -e "${RED}Failed${NOCOLOR}"

--- a/setup.sh
+++ b/setup.sh
@@ -5,6 +5,9 @@ RED="\033[1;31m"
 GREEN="\033[1;32m"
 YELLOW="\033[1;33m"
 NOCOLOR="\033[0m"
+# avoids an edgecase where employees do not have 1password accounts set up
+BC_RAW_1PASS_ID="CMUGFRT7Y5BRJMYKQIXJDO2654"
+
 
 function abort {
     echo -e "\n${RED}Exiting early, please re-run after correcting errors!${NOCOLOR}"
@@ -100,7 +103,7 @@ else
 fi
 
 echo -ne "${YELLOW}Testing 1Password CLI...${NOCOLOR} "
-if op account get --account bigcartel > /dev/null 2>&1; then
+if op account get --account $BC_RAW_1PASS_ID > /dev/null 2>&1; then
     echo -e "${GREEN}Success${NOCOLOR}"
 else
     echo -e "${RED}Failed${NOCOLOR}"
@@ -108,8 +111,10 @@ else
     abort
 fi
 
+# avoids an edgecase where employees do not have 1password accounts set up
+BC_RAW_1PASS_ID="CMUGFRT7Y5BRJMYKQIXJDO2654"
 echo -ne "${YELLOW}Testing Access to developer vaults...${NOCOLOR} "
-if op --account bigcartel item get "Rails Secrets [admin]" > /dev/null 2>&1; then
+if op --account $BIGCARTEL_RAW_1PASS_ID item get "Rails Secrets [admin]" > /dev/null 2>&1; then
     echo -e "${GREEN}Success${NOCOLOR}"
 else
     echo -e "${RED}Failed${NOCOLOR}"


### PR DESCRIPTION
## What
1. update the loading of 'developer vault' credentials from 1Password to fail silently when not present.
2. make the same fix for the prior test for access to 1Password

## Why
the old way of doing it with `last_exit` would halt script execution if either of these actions failed, making their `else` cases inaccessable. This change will allow helpful error messages to be shown

## QA
1. shows a success case (data present) the old way. This works
2. shows a failure case (data missing) the old way. This does not work and would halt execution of the script to raise the error `"Rails Secrets [admiasdfn]" isn't an item. Specify the item with its UUID, name, or domain.`
3. shows a success case (data present) the *new way*. This works
4. shows a failure case (data missing) the *new way*. This also works in the sense that it fails quietly and gives the user a useful error.

![Uploading Screenshot 2025-01-22 at 12.31.24 PM.png…]()

