### PR TITLE
Ensure libyaml for compiling Ruby (psych)

### DIFF
--- a/setup.sh
+++ b/setup.sh
@@ -43,15 +43,15 @@ function brew_install {
     if [ ! -e "$2" ]; then
         echo -e "\nInstalling ${GREEN}$1${NOCOLOR}..."
         brew install $1
-    else   
+    else
         echo -e "Skipping ${YELLOW}$1${NOCOLOR} - already installed"
     fi
 }
 
 if brew list libyaml &>/dev/null; then
-  echo "libyaml is already installed, skipping."
+  echo -e "Skipping ${YELLOW}libyaml${NOCOLOR} - already installed"
 else
-  echo "Installing libyaml..."
+  echo -e "\nInstalling ${GREEN}libyaml${NOCOLOR}..."
   brew install --quiet libyaml
 fi
 

--- a/setup.sh
+++ b/setup.sh
@@ -55,12 +55,12 @@ else
   brew install --quiet libyaml
 fi
 
-brew_install "orbstack" "/Applications/OrbStack.app"
+brew_install "1password-cli" "/opt/homebrew/bin/op"
 brew_install "gh" "/opt/homebrew/bin/gh"
 brew_install "mas" "/opt/homebrew/bin/mas"
-brew_install "stripe/stripe-cli/stripe" "/opt/homebrew/bin/stripe"
 brew_install "mise" "/opt/homebrew/bin/mise"
-brew_install "1password-cli" "/opt/homebrew/bin/op"
+brew_install "orbstack" "/Applications/OrbStack.app"
+brew_install "stripe/stripe-cli/stripe" "/opt/homebrew/bin/stripe"
 
 if [ ! -e "/Applications/Tailscale.app" ]; then
     echo -e "Installing ${GREEN}Tailscale${NOCOLOR}..."

--- a/setup.sh
+++ b/setup.sh
@@ -48,6 +48,13 @@ function brew_install {
     fi
 }
 
+if brew list libyaml &>/dev/null; then
+  echo "libyaml is already installed, skipping."
+else
+  echo "Installing libyaml..."
+  brew install --quiet libyaml
+fi
+
 brew_install "orbstack" "/Applications/OrbStack.app"
 brew_install "gh" "/opt/homebrew/bin/gh"
 brew_install "mas" "/opt/homebrew/bin/mas"


### PR DESCRIPTION
## Problem

Without libyaml, ruby 3.4 can't compile psych. Our setup script can handle this, but needs a small tweak to handle libraries properly (as opposed to executables)

### Error
```
*** Following extensions are not compiled:
psych:
	Could not be configured. It will not be installed.
	Check /var/folders/93/fnlprbgn0zvdz2zlbk859b1c0000gn/T/ruby-build.20250430114531.3173.cBuFak/ruby-3.4.3/ext/psych/mkmf.log for more details.
```

### Steps
- **Install libyaml if not installed**
- **Alphabetize the installed homebrew apps**
- **Update output with colors to keep in sync**
