### PR TITLE
Only upgrade brew and cleanup -- leave casks and brews alone

### DIFF
--- a/setup.sh
+++ b/setup.sh
@@ -33,7 +33,7 @@ if [ ! -e "/opt/homebrew/bin/brew" ]; then
 else
     echo -e "${GREEN}Homebrew found. Updating/Upgrading...${NOCOLOR}"
     activate_brew
-    brew update && brew upgrade && brew upgrade --cask && brew cleanup
+    brew update && brew cleanup
 fi
 
 echo -e "\n${GREEN}### Installing packages ###${NOCOLOR}\n"


### PR DESCRIPTION
## Problem

Multiple runs of the `setup.sh` script will update homebrew brews and casks. This could be surprising behavior -- maybe it makes sense to upgrade existing brews and casks _that are relevant to this script_ but the broad `brew upgrade` ensures EVERYTHING gets updated whether desired or not.

I think principle of least surprise makes sense here. Let users manage their brew manually. First-time users (clean machine) always get the latest versions already, folks running this again are either developing/testing, or otherwise should manage their brews independently.